### PR TITLE
Fix absolute path usage in scripts

### DIFF
--- a/extract_merge_gpt3.5.py
+++ b/extract_merge_gpt3.5.py
@@ -4,7 +4,8 @@ import os
 import glob
 import shutil
 
-BASE_DIR = "/Users/damian/git/openai-api-calls"
+# Determine the repository base directory from the location of this script
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 output_dir = os.path.join(BASE_DIR, "outputs")
 extracts_dir = os.path.join(BASE_DIR, "extracts")
 input_dir = os.path.join(BASE_DIR, "responses")

--- a/gpt35-smt.sh
+++ b/gpt35-smt.sh
@@ -54,7 +54,10 @@ function gpt35-smt() {
   echo "Input file path: ${input_filepath}"
   echo "Assistant message file path: ${assistant_message_filepath}"
 
-  python "/Users/damian/git/openai-api-calls/request_api_gpt3.5.py" \
+  # Determine the directory where this script resides to locate the Python helper
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  python "${script_dir}/request_api_gpt3.5.py" \
     --smf "${system_message_filepath}" \
     --mt "${max_tokens}" \
     --t "${t}" \

--- a/request_api_gpt3.5.py
+++ b/request_api_gpt3.5.py
@@ -125,5 +125,6 @@ def main():
 if __name__ == "__main__":
     main()
 
-# Merge and extract the content
-subprocess.run(["python", "/Users/damian/git/openai-api-calls/extract_merge_gpt3.5.py"])
+# Merge and extract the content using the script located in the same directory
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+subprocess.run(["python", os.path.join(SCRIPT_DIR, "extract_merge_gpt3.5.py")])


### PR DESCRIPTION
## Summary
- remove hardcoded user directories
- compute base directory from script location
- update bash helper to call python script in same repo

## Testing
- `python -m py_compile request_api_gpt3.5.py extract_merge_gpt3.5.py request_api.py extract_merge.py`

------
https://chatgpt.com/codex/tasks/task_e_68694afbc0a0832799d588475150a57f