### PR TITLE
docs: fix source path comment in gpt35-smt.sh

### DIFF
--- a/gpt35-smt.sh
+++ b/gpt35-smt.sh
@@ -70,4 +70,4 @@ function gpt35-smt() {
 }
 
 # Add the function to .bashrc or .bash_profile
-echo "source /path/to/gpt35-smt-bash-function.sh" >> ~/.bashrc  # or ~/.bash_profile if using macOS
+echo "source /path/to/gpt35-smt.sh" >> ~/.bashrc  # or ~/.bash_profile if using macOS


### PR DESCRIPTION
## Summary
- correct the filename in gpt35-smt.sh final comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694c103578832798223d87ebea0b44