### PR TITLE
fix: make input file argument mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The Bash alias function simplifies the usage of the Python script by providing a
 You can also use the Python script directly by running the request_api_gpt3.5.py script:
 `python request_api_gpt3.5.py --smf "system_message_filepath" --mt max_tokens --t temperature --n n --amf "assistant_message_filepath" --tp top_p --fp frequency_penalty --pp presence_penalty "input_filepath"`
 
+The final positional argument `input_filepath` is **required** and should point to the prompt file or directory.
+
 ### Example:
 `python request_api_gpt3.5.py --smf "./system-messages/Technology/ansible_playbook" --mt 1000 --t 1.0 --n 3 --amf "./prompts/assistant-messages/Technology/ansible" --tp 1.0 --fp 0.0 --pp 0.0 "./prompts/ansible_playbook"`
 

--- a/request_api_gpt3.5.py
+++ b/request_api_gpt3.5.py
@@ -92,7 +92,7 @@ def main():
     parser.add_argument("--tp", type=float, help="Top_p value", default=1.0)
     parser.add_argument("--fp", type=float, help="Frequency penalty", default=0.0)
     parser.add_argument("--pp", type=float, help="Presence penalty", default=0.0)
-    parser.add_argument("input_file", help="Path to input file containing prompt text", nargs='?')
+    parser.add_argument("input_file", help="Path to input file containing prompt text (required)")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- require the input file argument for `request_api_gpt3.5.py`
- document that the argument is mandatory

## Testing
- `python -m py_compile request_api_gpt3.5.py`

------
https://chatgpt.com/codex/tasks/task_e_68694c09d4dc83278087e594cb687215